### PR TITLE
Modify the sanitize function for saving Japanese characters

### DIFF
--- a/src/extension/utils/sanitize.ts
+++ b/src/extension/utils/sanitize.ts
@@ -4,23 +4,23 @@
 
 /**
  * Removes control characters and non-printable characters from text
- * while preserving newlines
+ * while preserving newlines and Japanese characters
  */
 export function sanitizeUserInput(text: string): string {
   return text
     .replace(/\r\n/g, "\n") // Normalize line endings
-    .replace(/[\x00-\x09\x0B-\x1F\x7F-\uFFFF]/g, "") // Remove control chars except newline
-    .replace(/[^\x20-\x7E\n]/g, "") // Remove non-ASCII chars except newline
+    .replace(/[\x00-\x09\x0B-\x1F]/g, "") // Remove control chars except newline
     .trim();
 }
 
 /**
  * Removes any shell prompt artifacts from terminal output
+ * while preserving Japanese characters
  */
 export function sanitizeTerminalOutput(text: string): string {
   return text
     .replace(/\r/g, "") // Remove standalone CR
     .replace(/[%$#>]\s*$/, "") // Remove shell prompts
-    .replace(/[\x00-\x09\x0B-\x1F\x7F-\uFFFF]/g, "") // Remove control chars
+    .replace(/[\x00-\x09\x0B-\x1F]/g, "") // Remove control chars
     .trim();
 }


### PR DESCRIPTION
ASCII characters were excluded from sanitization because they were being sanitized, preventing instructions from being issued, which caused difficulties for non-English speakers.