### PR TITLE
Fix typo in version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "julesmons",
   "name": "recline",
   "displayName": "Recline",
-  "version": "0.2.2",
+  "version": "0.2.12",
   "packageManager": "pnpm@9.15.2",
   "description": "Recline: The autonomous AI assistant that seamlessly integrates with your CLI and editor to create, edit, and run; redefining how you code.",
   "author": {


### PR DESCRIPTION
The version number has been reverted.
The next version after 0.2.11 should be 0.2.12.

refs
https://github.com/s4na/recline/commit/ec0d547018a7b20d454019f79c9ecee6d1990882#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5
